### PR TITLE
Disable default portal, load modules

### DIFF
--- a/lrbd
+++ b/lrbd
@@ -1219,8 +1219,8 @@ class Backstores(object):
             self.selected = backstore
 
         # Added to python-rtslib 104105
-        #if (self.selected == "rbd"):
-        #    self._load_modules()
+        if (self.selected == "rbd"):
+            self._load_modules()
         self._cmd()
         Runtime.config['backstore'] = self.selected
 
@@ -1513,8 +1513,21 @@ class TPGs(object):
         self.portal_index = portal_index
         self.lun_assignment = lun_assignment
 
+        self.disable_auto_add_default_portal()
         self._add()
         Runtime.config['portals'] = self.portal_index.portals
+
+    def disable_auto_add_default_portal(self):
+        """
+        Disable auto portal of 0.0.0.0
+        """
+        proc = Popen(["targetcli", "get", "global", "auto_add_default_portal"],
+                     stdout=PIPE, stderr=PIPE)
+        for line in proc.stdout:
+            results = re.split(r'=', line.decode('utf-8'))
+            if results[1].rstrip() != 'false':
+                cmd = ["targetcli", "set", "global", "auto_add_default_portal=false"]
+                popen(cmd)
 
     def _add(self):
         """

--- a/test/test_tpgs.py
+++ b/test/test_tpgs.py
@@ -33,10 +33,13 @@ class TPGsTestCase(unittest.TestCase):
             def _add_target(self):
                 pass
 
+            def disable_auto_add_default_portal(self):
+                pass
+
         class Portal_Index(object):
             def portals(self):
                 pass
-        
+
         _pi = Portal_Index()
         self.t = mock_TPGs(None, _pi, None)
         assert ('addresses' in Runtime.config and
@@ -51,10 +54,14 @@ class TPGsTestCase(unittest.TestCase):
             def _check_portal(self):
                 pass
 
+            def disable_auto_add_default_portal(self):
+                pass
+
+
         class Portal_Index(object):
             def portals(self):
                 pass
-        
+
         _pi = Portal_Index()
         self.t = mock_TPGs(None, _pi, None)
         assert not self.t.cmds
@@ -77,7 +84,11 @@ class TPGsTestCase(unittest.TestCase):
 
             def _check_portal(self, name):
                 pass
+
             def _add_host(self, entry, target):
+                pass
+
+            def disable_auto_add_default_portal(self):
                 pass
 
         class Portal_Index(object):
@@ -109,6 +120,9 @@ class TPGsTestCase(unittest.TestCase):
             def _remote(self):
                 pass
 
+            def disable_auto_add_default_portal(self):
+                pass
+
         class Portal_Index(object):
             def portals(self):
                 pass
@@ -126,6 +140,9 @@ class TPGsTestCase(unittest.TestCase):
                 pass
 
             def _remote(self):
+                pass
+
+            def disable_auto_add_default_portal(self):
                 pass
 
         class Portal_Index(object):
@@ -169,6 +186,9 @@ class TPGsTestCase(unittest.TestCase):
             def _remote(self):
                 pass
 
+            def disable_auto_add_default_portal(self):
+                pass
+
         class Portal_Index(object):
             def portals(self):
                 pass
@@ -189,6 +209,9 @@ class TPGsTestCase(unittest.TestCase):
             def _remote(self):
                 pass
 
+            def disable_auto_add_default_portal(self):
+                pass
+
         class Portal_Index(object):
             def portals(self):
                 pass
@@ -207,6 +230,9 @@ class TPGsTestCase(unittest.TestCase):
                 pass
 
             def _remote(self):
+                pass
+
+            def disable_auto_add_default_portal(self):
                 pass
 
         class Portal_Index(object):


### PR DESCRIPTION
targetcli-fb enables auto_add_default_portal by default which conflicts with subsequent portal creations.  Disable before creating portals.

Signed-off-by: Eric Jackson <swiftgist@gmail.com>